### PR TITLE
Ray tune hparam with hydra

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ python main.py model=dinov2_cls dataset=benv2_rgb output_dir=experiments/dinov2_
 
 overwrites the output directory where experiments are stored, batch size, epochs and learning rate.
 
+## Hyperparameter Tuning
+
+There is also a script included that can optimize hyperparameters with [Ray Tune](https://docs.ray.io/en/latest/tune/index.html) similar to the hydra setup above but with additional parameters for hparam tuning.
+
+The python file `generate_bash_scripts_ray_tune.py` can generate bash scripts that execute the `src/hparam_ray_hdra.py` script with optimizing the learning rate and batch size. The additonal ray relevant parameters are `cfg.ray.{something}` inside that script. Some defaults are provided, but if you need more specific control over ray tune configuration, additional ray arguments can be passed to the command line or a script with the plus sign. For more information you can see how the `generate_bash_scripts_ray_tune.py` configures an experiment.
 
 ---
 

--- a/scripts/generate_bash_scripts_ray_tune.py
+++ b/scripts/generate_bash_scripts_ray_tune.py
@@ -6,7 +6,6 @@ experiments = [
         "model": "dinov2_cls",
         "dataset": "benv2_rgb",
         "task": "classification",
-        "batch_size": 16,
         "epochs": 30,
         "lr_min": 0.001,
         "lr_max": 0.1,
@@ -24,7 +23,6 @@ def generate_bash_scripts(experiments, out_dir="."):
         dataset_dir = os.path.join(out_dir, "tune", dataset)
         os.makedirs(dataset_dir, exist_ok=True)
 
-        batch_size = exp["batch_size"]
         epochs = exp["epochs"]
         task = exp["task"]
         batch_choices = exp["batch_choices"]
@@ -49,7 +47,6 @@ export GEO_BENCH_DIR=/mnt/data/cc_benchmark
 
 model="{model}"
 dataset="{dataset}"
-batch_size="{batch_size}"
 lr_min="{lr_min}"
 lr_max="{lr_max}"
 task="{task}"

--- a/scripts/generate_bash_scripts_ray_tune.py
+++ b/scripts/generate_bash_scripts_ray_tune.py
@@ -1,0 +1,87 @@
+import os
+
+models = ["dinov2_cls"]
+experiments = [
+    {
+        "model": "dinov2_cls",
+        "dataset": "benv2_rgb",
+        "task": "classification",
+        "batch_size": 16,
+        "epochs": 30,
+        "lr_min": 0.001,
+        "lr_max": 0.1,
+        "batch_choices": [64, 128, 256],
+        "warmup_epochs": 3,
+    }
+]
+
+
+def generate_bash_scripts(experiments, out_dir="."):
+    os.makedirs(out_dir, exist_ok=True)
+    for exp in experiments:
+        model = exp["model"]
+        dataset = exp["dataset"]
+        dataset_dir = os.path.join(out_dir, "tune", dataset)
+        os.makedirs(dataset_dir, exist_ok=True)
+
+        batch_size = exp["batch_size"]
+        epochs = exp["epochs"]
+        task = exp["task"]
+        batch_choices = exp["batch_choices"]
+        # batch_choices_str = " ".join(str(x) for x in batch_choices)
+        batch_choices_str = "[" + ",".join(str(x) for x in batch_choices) + "]"
+
+        lr_min = exp["lr_min"]
+        lr_max = exp["lr_max"]
+        warmup_epochs = exp.get("warmup_epochs", 0)
+
+        script_name = f"run_{model}_{dataset}.sh"
+        script_path = os.path.join(dataset_dir, script_name)
+
+        # Generate script content
+        script_content = f"""#!/bin/bash
+echo "Contents of the current directory:"
+ls -lah
+
+export CUDA_VISIBLE_DEVICES=0
+export GEO_BENCH_DIR=/mnt/data/cc_benchmark
+
+
+model="{model}"
+dataset="{dataset}"
+batch_size="{batch_size}"
+lr_min="{lr_min}"
+lr_max="{lr_max}"
+task="{task}"
+batch_choices_str="{batch_choices_str}"
+
+
+epochs="{epochs}"
+warmup_epochs="{warmup_epochs}"
+num_gpus=$(echo $CUDA_VISIBLE_DEVICES | tr ',' '\\n' | wc -l)
+
+/home/toolkit/.conda/envs/dofaEnv/bin/python src/hparam_ray_hydra.py \\
+output_dir=/mnt/results/nils/exps/${{model}}_${{dataset}} \\
+model=${{model}} \\
+dataset=${{dataset}} \\
+task=${{task}} \\
+num_gpus=${{num_gpus}} \\
+num_workers=8 \\
+epochs=${{epochs}} \\
+warmup_epochs=${{warmup_epochs}} \\
+seed=42 \\
++ray.lr_min=${{lr_min}} \\
++ray.lr_max=${{lr_max}} \\
++ray.batch_choices=${{batch_choices_str}} \\
+"""
+
+        with open(script_path, "w") as f:
+            f.write(script_content)
+
+        os.chmod(script_path, 0o755)
+
+
+if __name__ == "__main__":
+    # Generate scripts in the same directory as this file
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    generate_bash_scripts(experiments, out_dir=script_dir)

--- a/src/hparam_ray_hydra.py
+++ b/src/hparam_ray_hydra.py
@@ -1,0 +1,132 @@
+import datetime
+import os
+from pathlib import Path
+from typing import Dict, Any
+
+import hydra
+from omegaconf import DictConfig
+import ray
+from ray import tune
+from ray.tune.schedulers import ASHAScheduler
+from ray.tune.search.optuna import OptunaSearch
+from ray.train.lightning import (
+    RayDDPStrategy,
+    RayLightningEnvironment,
+    RayTrainReportCallback,
+)
+from ray.train.torch import TorchTrainer
+from ray.train import RunConfig, ScalingConfig
+
+from lightning import Trainer, seed_everything
+from lightning.pytorch.loggers import MLFlowLogger
+
+from datasets.data_module import BenchmarkDataModule
+from factory import create_model
+
+
+def train_with_tune(config: Dict[str, Any], hydra_config: DictConfig) -> None:
+    """Train function for a single Ray Tune trial using Hydra config."""
+    seed_everything(hydra_config.seed)
+
+    # Update config with trial-specific hyperparameters
+    hydra_config.lr = config["lr"]
+    hydra_config.batch_size = config["batch_size"]
+
+    # Setup logging
+    experiment_name = f"{hydra_config.model.model_type}_{hydra_config.dataset.dataset_name}"
+    mlf_logger = MLFlowLogger(
+        experiment_name=experiment_name,
+        run_name=f"{experiment_name}_trial_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}",
+        tracking_uri=f"file:{os.path.join(hydra_config.output_dir, 'mlruns')}",
+    )
+
+    # Initialize data and model
+    data_module = BenchmarkDataModule(
+        dataset_config=hydra_config.dataset,
+        batch_size=config["batch_size"],
+        num_workers=hydra_config.num_workers,
+        pin_memory=hydra_config.pin_mem,
+    )
+    model = create_model(hydra_config, hydra_config.model, hydra_config.dataset)
+
+    # Create trainer with Ray-specific settings
+    trainer = Trainer(
+        max_epochs=hydra_config.epochs,
+        strategy=RayDDPStrategy(),
+        callbacks=[RayTrainReportCallback()],
+        plugins=[RayLightningEnvironment()],
+        logger=mlf_logger,
+        accelerator="auto",
+        devices="auto",
+    )
+
+    trainer = ray.train.lightning.prepare_trainer(trainer)
+    trainer.fit(model, data_module)
+
+@hydra.main(config_path="configs", config_name="config", version_base=None)
+def main(cfg: DictConfig) -> None:
+    """Main function combining Hydra and Ray"""
+    
+    # Setup directories
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    cfg.output_dir = f"{cfg.output_dir}_{timestamp}"
+    Path(cfg.output_dir).mkdir(parents=True, exist_ok=True)
+
+    # Ray configuration
+    scaling_config = ScalingConfig(
+        num_workers=1,
+        use_gpu=True,
+        resources_per_worker={
+            "CPU": cfg.ray.get('cpus_per_trial', 4),
+            "GPU": cfg.ray.get('gpus_per_trial', 1)
+        }
+    )
+    
+    run_config = RunConfig(
+        storage_path=cfg.output_dir,
+        name=f"tune_{cfg.model.model_type}_{cfg.dataset.dataset_name}"
+    )
+
+    ray_trainer = TorchTrainer(
+        tune.with_parameters(train_with_tune, hydra_config=cfg),
+        scaling_config=scaling_config,
+        run_config=run_config,
+    )
+
+    # Search space from args
+    search_space = {
+        "lr": tune.loguniform(cfg.ray.lr_min, cfg.ray.lr_max),
+        "batch_size": tune.choice(cfg.ray.batch_choices),
+    }
+
+    model_monitor = "val_miou" if cfg.task == "segmentation" else "val_acc1"
+    # Setup tuner
+    tuner = tune.Tuner(
+        ray_trainer,
+        param_space={"train_loop_config": search_space},
+        tune_config=tune.TuneConfig(
+            metric=model_monitor,
+            mode="max",
+            num_samples=cfg.ray.get('num_samples', 10),
+            scheduler=ASHAScheduler(
+                max_t=cfg.epochs,
+                grace_period=cfg.ray.get('grace_period', 5)
+            ),
+            search_alg=OptunaSearch(),
+        ),
+    )
+
+    results = tuner.fit()
+
+    best_trial = results.get_best_result(model_monitor, "max")
+
+    # write to file
+    best_trial_file = os.path.join(args.output_dir, "best_trial.txt")
+    with open(best_trial_file, "w") as f:
+        f.write(f"Best trial config: {best_trial.config}\n")
+        f.write(f"Best trial final metric: {best_trial[model_monitor]}\n")
+
+    ray.shutdown()
+    
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a python file to generate bash scripts that can then be run with the existing hydra setup for hyperparameter tuning with ray. It provides an outline of the moving pieces, but could be changed for different hparam strategies etc.

At the moment, the script tunes learning rate and batch size.